### PR TITLE
initial rpm spec & tito properties for building in koji

### DIFF
--- a/ovirt-puppet.spec
+++ b/ovirt-puppet.spec
@@ -1,0 +1,36 @@
+Name:       ovirt-puppet
+Epoch:      1
+Version:    0.0.1
+Release:    1%{?dotalphatag}%{?dist}
+Summary:    Collection of Puppet modules for oVirt deployment
+Group:      Applications/System
+License:    GPLv3+ and ASL 2.0
+URL:        https://github.com/fusor
+Source0:    %{name}-%{version}%{?dashalphatag}.tar.gz
+
+BuildArch:  noarch
+
+Requires:   puppet >= 2.7.0
+BuildRequires: puppet >= 2.7.0
+BuildRequires: hostname
+
+%description
+A collection of Puppet modules which are required to install and configure
+oVirt via installers using Puppet configuration tool.
+
+%prep
+%setup -q -n %{name}-%{version}%{?dashalphatag}
+
+%build
+puppet module build .
+
+%install
+rm -rf %{buildroot}
+install -d -m 0755 %{buildroot}/%{_datadir}/ovirt-puppet
+cp -r * %{buildroot}/%{_datadir}/ovirt-puppet
+
+%files
+%{_datadir}/ovirt-puppet/*
+
+%changelog
+

--- a/rel-eng/releasers.conf
+++ b/rel-eng/releasers.conf
@@ -1,0 +1,18 @@
+[cvs]
+releaser = tito.release.CvsReleaser
+cvsroot = :gserver:cvs.devel.redhat.com:/cvs/dist
+branches = RHEL-6-SE
+
+[git]
+releaser = tito.release.DistGitReleaser
+branches = se-rhel-6
+
+[koji]
+releaser = tito.release.KojiReleaser
+autobuild_tags = fusor-nightly-el6 fusor-nightly-el7
+
+[koji-head]
+releaser = tito.release.KojiReleaser
+autobuild_tags = fusor-nightly-el6 fusor-nightly-el7
+builder.test = 1
+

--- a/rel-eng/tito.props
+++ b/rel-eng/tito.props
@@ -1,0 +1,13 @@
+[buildconfig]
+builder = tito.builder.Builder
+tagger = tito.tagger.ReleaseTagger
+changelog_do_not_remove_cherrypick = 0
+changelog_format = %s (%ae)
+
+[fusor-nightly-rhel6]
+disttag = .el6
+blacklist =
+
+[fusor-nightly-rhel7]
+disttag = .el7
+blacklist =


### PR DESCRIPTION
This commit contains the initial changes to allow a user to build an ovirt-puppet rpm using koji.

An example test scenario:

tito build --test --srpm --dist=.el7

koji -c ~/.koji/katello-config build --scratch katello-nightly-rhel7 /tmp/tito/rubygem-fusor_ui-0.0.1-1.el7.git.0.cf2d5be.src.rpm
