### PR TITLE
ovirt_release_base_url is a parameter of ovirt::repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,12 +83,12 @@ Classes:
 * [ovirt::engine](#class-ovirtengine)
 * [ovirt::node](#class-ovirtnode)
 
-###Class: ovirt:
+###Class: ovirt::repo
 This class allows you to change the URL for the oVirt release package.
 
 For example, if you maintain a local repository you could do this:
 
-    class { 'ovirt::engine':
+    class { 'ovirt::repo':
       ovirt_release_base_url => 'http://ovirt.local.com/releases',
     }
 


### PR DESCRIPTION
The class ovirt by itself doesn't have any parameters, this commit corrects the README to point out the correct class.
